### PR TITLE
Allow for a `hard_left` g:lightline_gruvbox_style

### DIFF
--- a/plugin/lightline-gruvbox.vim
+++ b/plugin/lightline-gruvbox.vim
@@ -99,9 +99,15 @@ if s:style == 'plain'
 else
 	let s:p.normal.middle = [
 				\ [s:mono4, s:mono1, s:c_mono4, s:c_mono1]]
-	let s:p.normal.left = [
-				\ [s:mono0, s:green, s:c_mono0, s:c_green],
-				\ [s:mono5, s:mono3, s:c_mono5, s:c_mono3]]
+	if s:style == 'hard_left'
+		let s:p.normal.left = [
+					\ [s:mono0, s:green, s:c_mono0, s:c_green],
+					\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]
+	else
+		let s:p.normal.left = [
+					\ [s:mono0, s:green, s:c_mono0, s:c_green],
+					\ [s:mono5, s:mono3, s:c_mono5, s:c_mono3]]
+	endif
 	let s:p.normal.right = [
 				\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4],
 				\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]


### PR DESCRIPTION
Do this because I was really struggling to see the information I kept next to my mode indicator.  The combination of `mono5` and `mono3` wasn't really legible on my monitor.  Add a toggle though so the changes are optional and the defaults are backwards compatible.

I realize this is all subjective, so feel more than free to just discard this pull request.

Thanks for putting this all together in the first place!