### PR TITLE
Add ability to change rhs color, change configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ let g:lightline = {}
 let g:lightline.colorscheme = 'gruvbox'
 ```
 
+Configuration
+----------------
+
+Configure bar coloring with either `left`, `right`, `both` like so
+```vim
+let g:lightline_gruvbox_color = '<coloring>'
+```
+or set to empty for no coloring. Defaults to `left`.
+
+Configure the style with `hard`, or `plain` (depricated) like so
+```vim
+let g:lightline_gruvbox_style = '<style>'
+```
+Defaults to neither
+
 Screenshots
 ----------------
 ### Dark

--- a/plugin/lightline-gruvbox.vim
+++ b/plugin/lightline-gruvbox.vim
@@ -4,6 +4,9 @@
 " Source: https://github.com/shinchu/lightline-gruvbox
 
 let s:is_dark=(&background == 'dark')
+let s:right_color = exists('g:gruvbox_lightline_color_right')
+					\ ? g:gruvbox_lightline_color_right
+					\ : 0
 
 if !exists('g:gruvbox_contrast_dark')
   let g:gruvbox_contrast_dark='medium'
@@ -108,9 +111,15 @@ else
 					\ [s:mono0, s:green, s:c_mono0, s:c_green],
 					\ [s:mono5, s:mono3, s:c_mono5, s:c_mono3]]
 	endif
-	let s:p.normal.right = [
-				\ [s:mono0, s:green, s:c_mono0, s:c_green],
-				\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]
+	if s:right_color
+		let s:p.normal.right = [
+					\ [s:mono0, s:green, s:c_mono0, s:c_green],
+					\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]
+	else
+		let s:p.normal.right = [
+					\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4],
+					\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]
+	endif
 endif
 
 let s:p.inactive.middle = [
@@ -125,23 +134,26 @@ let s:p.inactive.left = [
 let s:p.insert.left = [
 			\ [s:mono0, s:blue, s:c_mono0, s:c_blue],
 			\ s:p.normal.left[1]]
-let s:p.insert.right = [
-			\ [s:mono0, s:blue, s:c_mono0, s:c_blue],
-			\ s:p.normal.right[1]]
 
 let s:p.replace.left = [
 			\ [s:mono0, s:red, s:c_mono0, s:c_red],
 			\ s:p.normal.left[1]]
-let s:p.replace.right = [
-			\ [s:mono0, s:red, s:c_mono0, s:c_red],
-			\ s:p.normal.right[1]]
 
 let s:p.visual.left = [
 			\ [s:mono0, s:orange, s:c_mono0, s:c_orange],
 			\ s:p.normal.left[1]]
-let s:p.visual.right = [
-			\ [s:mono0, s:orange, s:c_mono0, s:c_orange],
-			\ s:p.normal.right[1]]
+
+if s:right_color
+	let s:p.insert.right = [
+				\ [s:mono0, s:blue, s:c_mono0, s:c_blue],
+				\ s:p.normal.right[1]]
+	let s:p.replace.right = [
+				\ [s:mono0, s:red, s:c_mono0, s:c_red],
+				\ s:p.normal.right[1]]
+	let s:p.visual.right = [
+				\ [s:mono0, s:orange, s:c_mono0, s:c_orange],
+				\ s:p.normal.right[1]]
+endif
 
 if s:style == 'plain'
 	let s:p.tabline.middle = [

--- a/plugin/lightline-gruvbox.vim
+++ b/plugin/lightline-gruvbox.vim
@@ -83,65 +83,61 @@ let s:p = {
 			\ 'visual':   {},
 			\ 'tabline':  {}}
 
+" Valid Values '', 'hard', 'plain' ('plain' forces color = '')
 let s:style = exists('g:lightline_gruvbox_style')
-			\ ? g:lightline_gruvbox_style
+			\ ? get(g:, 'lightline_gruvbox_style', '')
 			\ : ''
 
-if s:style == 'plain'
-	let s:p.normal.middle = [
-				\ [s:mono3, s:mono4, s:c_mono3, s:c_mono4]]
-	let s:p.normal.left = [
-				\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4],
-				\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]
-	let s:p.normal.right = [
-				\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4],
-				\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]
-else
-	let s:p.normal.middle = [
-				\ [s:mono4, s:mono1, s:c_mono4, s:c_mono1]]
-	if s:style == 'hard_left' || s:style == 'hard'
-		let s:p.normal.left = [
-					\ [s:mono0, s:green, s:c_mono0, s:c_green],
-					\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]
-	else
-		let s:p.normal.left = [
-					\ [s:mono0, s:green, s:c_mono0, s:c_green],
-					\ [s:mono5, s:mono3, s:c_mono5, s:c_mono3]]
-	endif
+" Valid Values 'left', 'right', 'both', ''
+let s:color = exists('g:lightline_gruvbox_color')
+			\ ? get(g:, 'lightline_gruvbox_color', '') : 'left'
 
-	if s:style == 'hard'
-		let s:p.normal.right = [
-					\ [s:mono0, s:green, s:c_mono0, s:c_green],
-					\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]
-	else
-		let s:p.normal.right = [
-					\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4],
-					\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]
-	endif
+if s:style ==? 'plain'
+	let s:color = ''
 endif
 
-let s:p.inactive.middle = [
-			\ [s:mono4, s:mono2, s:c_mono4, s:c_mono2]]
-let s:p.inactive.right = [
-			\ s:p.inactive.middle[0],
-			\ s:p.inactive.middle[0]]
-let s:p.inactive.left = [
-			\ s:p.inactive.middle[0],
-			\ s:p.inactive.middle[0]]
+let s:p.normal.middle = [
+			\ [s:mono4, s:mono1, s:c_mono4, s:c_mono1]]
+let s:p.normal.left = [
+			\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4],
+			\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]
+let s:p.normal.right = [
+			\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4],
+			\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]
 
-let s:p.insert.left = [
-			\ [s:mono0, s:blue, s:c_mono0, s:c_blue],
-			\ s:p.normal.left[1]]
+ 
+let s:p.tabline.middle = [
+			\ [s:mono4, s:mono1, s:c_mono4, s:c_mono1]]
+let s:p.tabline.right = [
+			\ [s:mono0, s:mono5, s:c_mono0, s:c_mono4]]
+let s:p.tabline.left = [
+			\ [s:mono0, s:mono5, s:c_mono0, s:c_mono4]]
+let s:p.tabline.tabsel = [
+			\ [s:mono5, s:mono0, s:c_mono0, s:c_mono5]]
 
-let s:p.replace.left = [
-			\ [s:mono0, s:red, s:c_mono0, s:c_red],
-			\ s:p.normal.left[1]]
+if s:color ==? 'left' || s:color ==? 'both'
+	let s:p.normal.left = [
+				\ [s:mono0, s:green, s:c_mono0, s:c_green],
+				\ [s:mono5, s:mono3, s:c_mono5, s:c_mono3]]
 
-let s:p.visual.left = [
-			\ [s:mono0, s:orange, s:c_mono0, s:c_orange],
-			\ s:p.normal.left[1]]
+	let s:p.insert.left = [
+				\ [s:mono0, s:blue, s:c_mono0, s:c_blue],
+				\ s:p.normal.left[1]]
 
-if s:style == 'hard'
+	let s:p.replace.left = [
+				\ [s:mono0, s:red, s:c_mono0, s:c_red],
+				\ s:p.normal.left[1]]
+
+	let s:p.visual.left = [
+				\ [s:mono0, s:orange, s:c_mono0, s:c_orange],
+				\ s:p.normal.left[1]]
+endif
+
+if s:color ==? 'right' || s:color ==? 'both'
+	let s:p.normal.right = [
+				\ [s:mono0, s:green, s:c_mono0, s:c_green],
+				\ [s:mono0, s:mono3, s:c_mono0, s:c_mono3]]
+
 	let s:p.insert.right = [
 				\ [s:mono0, s:blue, s:c_mono0, s:c_blue],
 				\ s:p.normal.right[1]]
@@ -153,16 +149,14 @@ if s:style == 'hard'
 				\ s:p.normal.right[1]]
 endif
 
-if s:style == 'plain'
-	let s:p.tabline.middle = [
-				\ [s:mono0, s:mono5, s:c_mono0, s:c_mono4]]
-	let s:p.tabline.right = [
-				\ [s:mono0, s:mono5, s:c_mono0, s:c_mono4]]
-	let s:p.tabline.left = [
-				\ [s:mono0, s:mono5, s:c_mono0, s:c_mono4]]
-	let s:p.tabline.tabsel = [
-				\ [s:mono5, s:mono0, s:c_mono0, s:c_mono5]]
-else
+if s:style ==? 'hard'
+	let s:p.normal.left = [
+				\ s:p.normal.left[0],
+				\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]
+	let s:p.normal.right = [
+				\ s:p.normal.right[0],
+				\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]
+
 	let s:p.tabline.middle = [
 				\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]
 	let s:p.tabline.right = [
@@ -172,6 +166,15 @@ else
 				\ [s:mono4, s:mono1, s:c_mono4, s:c_mono1]]
 	let s:p.tabline.tabsel = [
 				\ [s:mono5, s:mono0, s:c_mono5, s:c_mono0]]
-endif
+end
+
+let s:p.inactive.middle = [
+			\ [s:mono4, s:mono2, s:c_mono4, s:c_mono2]]
+let s:p.inactive.right = [
+			\ s:p.inactive.middle[0],
+			\ s:p.inactive.middle[0]]
+let s:p.inactive.left = [
+			\ s:p.inactive.middle[0],
+			\ s:p.inactive.middle[0]]
 
 let g:lightline#colorscheme#gruvbox#palette = s:p

--- a/plugin/lightline-gruvbox.vim
+++ b/plugin/lightline-gruvbox.vim
@@ -4,9 +4,6 @@
 " Source: https://github.com/shinchu/lightline-gruvbox
 
 let s:is_dark=(&background == 'dark')
-let s:right_color = exists('g:gruvbox_lightline_color_right')
-					\ ? g:gruvbox_lightline_color_right
-					\ : 0
 
 if !exists('g:gruvbox_contrast_dark')
   let g:gruvbox_contrast_dark='medium'
@@ -102,7 +99,7 @@ if s:style == 'plain'
 else
 	let s:p.normal.middle = [
 				\ [s:mono4, s:mono1, s:c_mono4, s:c_mono1]]
-	if s:style == 'hard_left'
+	if s:style == 'hard_left' || s:style == 'hard'
 		let s:p.normal.left = [
 					\ [s:mono0, s:green, s:c_mono0, s:c_green],
 					\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]
@@ -111,7 +108,8 @@ else
 					\ [s:mono0, s:green, s:c_mono0, s:c_green],
 					\ [s:mono5, s:mono3, s:c_mono5, s:c_mono3]]
 	endif
-	if s:right_color
+
+	if s:style == 'hard'
 		let s:p.normal.right = [
 					\ [s:mono0, s:green, s:c_mono0, s:c_green],
 					\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]
@@ -143,7 +141,7 @@ let s:p.visual.left = [
 			\ [s:mono0, s:orange, s:c_mono0, s:c_orange],
 			\ s:p.normal.left[1]]
 
-if s:right_color
+if s:style == 'hard'
 	let s:p.insert.right = [
 				\ [s:mono0, s:blue, s:c_mono0, s:c_blue],
 				\ s:p.normal.right[1]]

--- a/plugin/lightline-gruvbox.vim
+++ b/plugin/lightline-gruvbox.vim
@@ -1,7 +1,8 @@
 " File: lightline-gruvbox.vim
 " Description: lightline.vim theme for gruvbox colorscheme
 " Author: shinchu <shinchu@outlook.com>
-" Source: https://github.com/shinchu/lightline-gruvbox
+" Contributor: oldwomanjosiah <jhilden13@gmail.com>
+" Source: https://github.com/oldwomanjosiah/lightline-gruvbox.vim
 
 let s:is_dark=(&background == 'dark')
 

--- a/plugin/lightline-gruvbox.vim
+++ b/plugin/lightline-gruvbox.vim
@@ -109,7 +109,7 @@ else
 					\ [s:mono5, s:mono3, s:c_mono5, s:c_mono3]]
 	endif
 	let s:p.normal.right = [
-				\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4],
+				\ [s:mono0, s:green, s:c_mono0, s:c_green],
 				\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]
 endif
 
@@ -125,12 +125,23 @@ let s:p.inactive.left = [
 let s:p.insert.left = [
 			\ [s:mono0, s:blue, s:c_mono0, s:c_blue],
 			\ s:p.normal.left[1]]
+let s:p.insert.right = [
+			\ [s:mono0, s:blue, s:c_mono0, s:c_blue],
+			\ s:p.normal.right[1]]
+
 let s:p.replace.left = [
 			\ [s:mono0, s:red, s:c_mono0, s:c_red],
 			\ s:p.normal.left[1]]
+let s:p.replace.right = [
+			\ [s:mono0, s:red, s:c_mono0, s:c_red],
+			\ s:p.normal.right[1]]
+
 let s:p.visual.left = [
 			\ [s:mono0, s:orange, s:c_mono0, s:c_orange],
 			\ s:p.normal.left[1]]
+let s:p.visual.right = [
+			\ [s:mono0, s:orange, s:c_mono0, s:c_orange],
+			\ s:p.normal.right[1]]
 
 if s:style == 'plain'
 	let s:p.tabline.middle = [


### PR DESCRIPTION
- Added ability to color rhs
```vim
" 'left', 'right', 'both' for color, any other value for neither
" 'left' is default if left undefined
let g:lightline_gruvbox_color = 'both'
```
- Changed `g:lightline_gruvbox_style` to only react to 'hard' and 'plain,' though I consider 'plain' deprecated.