### PR TITLE
Add warning and error colors

### DIFF
--- a/plugin/lightline-gruvbox.vim
+++ b/plugin/lightline-gruvbox.vim
@@ -113,6 +113,9 @@ else
 				\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]
 endif
 
+let s:p.normal.error = [ [s:mono0, s:red, s:c_mono0, s:c_red] ]
+let s:p.normal.warning = [ [s:mono0, s:orange, s:c_mono0, s:c_orange] ]
+
 let s:p.inactive.middle = [
 			\ [s:mono4, s:mono2, s:c_mono4, s:c_mono2]]
 let s:p.inactive.right = [


### PR DESCRIPTION
Hi, @sinchu! Thanks for awesome plugin, I've been using it for couple years already.

Recently I switched to nvim's own lsp and started to use lightline-lsp, but I noticed warnings and errors are too dim and gray.
Then I checked on official Lightline themes and it seems they're using warning and error colors: https://github.com/itchyny/lightline.vim/blob/master/autoload/lightline/colorscheme/solarized.vim#L77
So I added them here too.

Before:

![image](https://user-images.githubusercontent.com/1912728/141444610-323c0301-06fb-4dd0-9985-c9ec2bcd4a43.png)

After:

![image](https://user-images.githubusercontent.com/1912728/141443784-fd3e89c9-7d8e-47fd-96ab-562f1fb80c16.png)

